### PR TITLE
Remove now redundant @babel/preset-env 'modules: false' option

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -27,7 +27,6 @@ module.exports = (neutrino, opts = {}) => {
       presets: [
         [require.resolve('@babel/preset-env'), {
           debug: neutrino.options.debug,
-          modules: false,
           useBuiltIns: 'entry',
           targets: options.target === 'node' ?
             { node: '8.3' } :

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -274,8 +274,7 @@ module.exports = {
           ['@babel/preset-env', {
             // Targets the version of Node.js used to run webpack.
             targets: { node: 'current' },
-            modules: false,
-            useBuiltIns: true,
+            useBuiltIns: 'entry',
           }]
         ]
       }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -45,7 +45,6 @@ module.exports = (neutrino, opts = {}) => {
         [require.resolve('@babel/preset-env'), {
           debug: neutrino.options.debug,
           targets: options.targets,
-          modules: false,
           useBuiltIns: 'entry'
         }]
       ]

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -227,7 +227,6 @@ module.exports = {
         // Override options for @babel/preset-env:
         presets: [
           ['@babel/preset-env', {
-            modules: false,
             useBuiltIns: true,
           }]
         ]

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -216,7 +216,6 @@ module.exports = {
         // Override options for @babel/preset-env:
         presets: [
           ['@babel/preset-env', {
-            modules: false,
             useBuiltIns: true,
           }]
         ]

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -232,7 +232,6 @@ module.exports = {
         // Override options for @babel/preset-env:
         presets: [
           ['@babel/preset-env', {
-            modules: false,
             useBuiltIns: true,
           }]
         ]

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -242,7 +242,6 @@ module.exports = {
         // Override options for @babel/preset-env:
         presets: [
           ['@babel/preset-env', {
-            modules: false,
             useBuiltIns: true,
           }]
         ]

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -87,7 +87,6 @@ module.exports = (neutrino, opts = {}) => {
       presets: [
         [require.resolve('@babel/preset-env'), {
           debug: neutrino.options.debug,
-          modules: false,
           useBuiltIns: 'entry',
           targets: options.targets
         }]


### PR DESCRIPTION
As of `@babel/preset-env@7.0.0-rc.2` and `babel-loader@8.0.0-beta.6` the `modules` option is automatically set to the correct value (ie: no ES6 to CJS conversion since webpack supports ES6 modules), so no longer needs to be specified by us.

See:
https://github.com/babel/babel/releases/v7.0.0-rc.2
https://github.com/babel/babel-loader/releases/tag/v8.0.0-beta.6
https://github.com/babel/babel-loader/pull/660